### PR TITLE
Locale update

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,17 +69,17 @@ This package assumes usage within a Qubit experience. If using elsewhere you can
 
 The Qubit Recommendations API endpoint.
 
-### currency
+### defaultCurrency
 *type*: `String`
 *default*: `currency` emitted in QP view event
 
-Allows you to override the currency for the recs endpoint locale; e.g. 'GBP'
+Allows you to add a fallback currency for the recs endpoint locale; e.g. 'GBP'
 
-### language
+### defaultLanguage
 *type*: `String`
 *default*: `language` emitted in QP view event
 
-Allows you to override the language for the recs endpoint locale; e.g. 'en-gb'
+Allows you to add a fallback language for the recs endpoint locale; e.g. 'en-gb'
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ This package assumes usage within a Qubit experience. If using elsewhere you can
 
 The Qubit Recommendations API endpoint.
 
+### currency
+*type*: `String`
+*default*: `currency` emitted in QP view event
+
+Allows you to override the currency for the recs endpoint locale; e.g. 'GBP'
+
+### language
+*type*: `String`
+*default*: `language` emitted in QP view event
+
+Allows you to override the language for the recs endpoint locale; e.g. 'en-gb'
+
 ## Usage
 
 ### Basic

--- a/get.js
+++ b/get.js
@@ -14,8 +14,8 @@ module.exports = function getRecommendations (config, options) {
     var url = settings.url || config.url
     var trackingId = settings.trackingId || config.trackingId
     var visitorId = settings.visitorId || config.visitorId
-    var currency = settings.currency || config.currency
-    var language = settings.language || config.language
+    var defaultCurrency = settings.defaultCurrency || config.defaultCurrency
+    var defaultLanguage = settings.defaultLanguage || config.defaultLanguage
 
     if (!_.isArray(seed)) {
       seed = [seed]
@@ -40,8 +40,8 @@ module.exports = function getRecommendations (config, options) {
 
     return getLocale({
       uv: options.uv,
-      currency: currency,
-      language: language
+      defaultCurrency: defaultCurrency,
+      defaultLanguage: defaultLanguage
     }).then(function (locale) {
       var requestUrl = [
         url,

--- a/get.js
+++ b/get.js
@@ -14,6 +14,8 @@ module.exports = function getRecommendations (config, options) {
     var url = settings.url || config.url
     var trackingId = settings.trackingId || config.trackingId
     var visitorId = settings.visitorId || config.visitorId
+    var currency = settings.currency || config.currency
+    var language = settings.language || config.language
 
     if (!_.isArray(seed)) {
       seed = [seed]
@@ -36,7 +38,11 @@ module.exports = function getRecommendations (config, options) {
       _.assign(data, { rules: rules })
     }
 
-    return getLocale({ uv: options.uv }).then(function (locale) {
+    return getLocale({
+      uv: options.uv,
+      currency: currency,
+      language: language
+    }).then(function (locale) {
       var requestUrl = [
         url,
         trackingId,

--- a/getLocale.js
+++ b/getLocale.js
@@ -3,8 +3,8 @@ const Promise = require('sync-p')
 module.exports = function getLocale (options) {
   return new Promise(function (resolve, reject) {
     options.uv.on(/^([^.]+\.)?[a-z]{2}View$/, function (event) {
-      var language = options.language || event.language
-      var currency = options.currency || event.currency
+      var language = event.language || options.defaultLanguage
+      var currency = event.currency || options.defaultCurrency
       var currentLocale = language || currency || ''
       if (language && currency) {
         currentLocale = [language, currency].join('-')

--- a/getLocale.js
+++ b/getLocale.js
@@ -3,8 +3,8 @@ const Promise = require('sync-p')
 module.exports = function getLocale (options) {
   return new Promise(function (resolve, reject) {
     options.uv.on(/^([^.]+\.)?[a-z]{2}View$/, function (event) {
-      var language = event.language
-      var currency = event.currency
+      var language = options.language || event.language
+      var currency = options.currency || event.currency
       var currentLocale = language || currency || ''
       if (language && currency) {
         currentLocale = [language, currency].join('-')

--- a/package-lock.json
+++ b/package-lock.json
@@ -2137,7 +2137,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2158,12 +2159,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2178,17 +2181,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2305,7 +2311,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2317,6 +2324,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2331,6 +2339,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2338,12 +2347,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2362,6 +2373,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2442,7 +2454,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2454,6 +2467,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2539,7 +2553,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2575,6 +2590,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2594,6 +2610,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2637,12 +2654,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -35,10 +35,9 @@ test('throws error if options is not present', () => {
 })
 
 describe('testing basic', () => {
+  let language = 'en-GB'
+  let currency = 'GBP'
   beforeEach(() => {
-    const language = 'en-gb'
-    const currency = 'GBP'
-    uv.emit('ecView', { language, currency })
     httpMock.__setRecs({
       result: {
         items: [ rec ]
@@ -46,25 +45,28 @@ describe('testing basic', () => {
     })
     getLocale.mockImplementation(options => {
       return Promise.resolve([
-        options.language || language,
-        options.language || currency
+        language || options.defaultLanguage,
+        currency || options.defaultCurrency
       ].join('-').toLowerCase())
     })
   })
 
   test('requested url is correct', async () => {
+    uv.emit('ecView', { language, currency })
     await recommendations(options).get()
     const calledUrl = httpMock.post.mock.calls[0][0]
     expect(calledUrl).toBe('https://recs.qubit.com/vc/recommend/2.0/menards?strategy=pop&id=123adwqddqdw&n=10&experienceId=123456&iterationId=600100&variationId=165767&locale=en-gb-gbp')
   })
 
   test('data passed is correct', async () => {
+    uv.emit('ecView', { language, currency })
     await recommendations(options).get()
     const data = httpMock.post.mock.calls[0][1]
     expect(data).toBe(JSON.stringify({ h: ['all'] }))
   })
 
   test('called with the correct timeout', async () => {
+    uv.emit('ecView', { language, currency })
     const EXPECTED_TIMEOUT = 1000
     await recommendations(options).get({ timeout: EXPECTED_TIMEOUT })
     const config = httpMock.post.mock.calls[0][2]
@@ -72,33 +74,50 @@ describe('testing basic', () => {
   })
 
   test('should call getLocale with current options', async () => {
+    uv.emit('ecView', { language, currency })
     await recommendations(options).get()
     expect(getLocale.mock.calls[0][0].uv).toEqual(options.uv)
   })
 
   test('getLocale uses view event when no overrides present', async () => {
+    uv.emit('ecView', { language, currency })
     const locale = await getLocale({ uv: options.uv })
     expect(locale).toEqual('en-gb-gbp')
   })
 
-  test('config overrides view event locale when present', async () => {
+  test('getLocale uses defaults when view event values not present', async () => {
+    language = null
+    currency = null
+    uv.emit('ecView', { language, currency })
+    const locale = await getLocale({
+      uv: options.uv,
+      defaultCurrency: 'USD',
+      defaultLanguage: 'en-US'
+    })
+    expect(locale).toEqual('en-us-usd')
+  })
+
+  test('locale defaults to config values when present', async () => {
+    uv.emit('ecView', { language: null, currency: null })
     const config = {
-      language: 'en-us',
-      currency: 'USD'
+      defaultLanguage: 'en-us',
+      defaultCurrency: 'USD'
     }
     const recommendations = require('../index.js')(options, config)
     await recommendations.get()
-    expect(getLocale.mock.calls[0][0].language).toEqual(config.language)
-    expect(getLocale.mock.calls[0][0].currency).toEqual(config.currency)
+    expect(getLocale.mock.calls[0][0].defaultLanguage).toEqual(config.defaultLanguage)
+    expect(getLocale.mock.calls[0][0].defaultCurrency).toEqual(config.defaultCurrency)
   })
 
-  test('settings override view event locale when presting', async () => {
-    const currencyOverride = 'USD'
-    await recommendations(options).get({ currency: currencyOverride })
-    expect(getLocale.mock.calls[0][0].currency).toEqual(currencyOverride)
+  test('locale defaults to request settings when present', async () => {
+    uv.emit('ecView', { language, currency: null })
+    const fallbackCurrency = 'USD'
+    await recommendations(options).get({ defaultCurrency: fallbackCurrency })
+    expect(getLocale.mock.calls[0][0].defaultCurrency).toEqual(fallbackCurrency)
   })
 
   test('responds with recs for basic setup', async () => {
+    uv.emit('ecView', { language, currency })
     expect.assertions(1)
 
     const recs = await recommendations(options).get()


### PR DESCRIPTION
As indicated in the following issue (https://github.com/QubitProducts/recommendations/issues/7) we often run into a problem whereby a client's QP implementation issues prevent devs from using this module; even though the recommendations endpoint has products that can be used.

While it is fair that a client should first arrange for the proper change(s) to be made to their QP implementation, this update allows for additional flexibility in the interim.

Welcome any thoughts on this matter