### PR TITLE
Ability to force the locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ Allows you to add a fallback currency for the recs endpoint locale; e.g. 'GBP'
 
 Allows you to add a fallback language for the recs endpoint locale; e.g. 'en-gb'
 
+### locale
+*type*: `String`
+*default*: `undefined`
+
+Allows you to override the default locale for the recs endpoint; e.g. 'en-gb'
+
 ## Usage
 
 ### Basic

--- a/get.js
+++ b/get.js
@@ -51,6 +51,7 @@ module.exports = function getRecommendations (config, options) {
     var visitorId = settings.visitorId || config.visitorId
     var defaultCurrency = settings.defaultCurrency || config.defaultCurrency
     var defaultLanguage = settings.defaultLanguage || config.defaultLanguage
+    var staticLocale = settings.locale || config.locale
 
     if (seed !== 'all') {
       if (!_.isArray(seed)) {
@@ -74,7 +75,8 @@ module.exports = function getRecommendations (config, options) {
     return getLocale({
       uv: options.uv,
       defaultCurrency: defaultCurrency,
-      defaultLanguage: defaultLanguage
+      defaultLanguage: defaultLanguage,
+      staticLocale: staticLocale
     }).then(function (locale) {
       var variables = {
         trackingId: trackingId,

--- a/getLocale.js
+++ b/getLocale.js
@@ -9,7 +9,8 @@ module.exports = function getLocale (options) {
       if (language && currency) {
         currentLocale = [language, currency].join('-')
       }
-      resolve(currentLocale.toLowerCase())
+      var locale = options.staticLocale || currentLocale
+      resolve(locale.toLowerCase())
     }).replay()
   })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2288,7 +2288,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2309,12 +2310,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2329,17 +2332,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2456,7 +2462,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2468,6 +2475,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2482,6 +2490,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2489,12 +2498,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2513,6 +2524,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2593,7 +2605,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2605,6 +2618,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2690,7 +2704,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2726,6 +2741,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2745,6 +2761,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2788,12 +2805,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -153,7 +153,8 @@ describe('testing basic', () => {
     const config = httpMock.query.mock.calls[0][2]
     expect(config).toEqual({
       timeout: EXPECTED_TIMEOUT,
-      url: 'https://api.qubit.com/graphql'
+      url: 'https://api.qubit.com/graphql',
+      package: '@qubit/recommendations'
     })
   })
 


### PR DESCRIPTION
Right now the locale might come from:
- the ecView events and the `language` and `currency` fields
- the fallback values of the config `defaultLanguage` and `defaultCurrency`

This PR is about forcing to use a specific locale. So ideally you could set the config such as:
```
 const config = {
  strategy: 'popular',
  limit: 42,
  seed: 'all',
  locale: 'fr-fr'
}
```
